### PR TITLE
Warn if package-lock has newer version than package (even if semver-compliant)

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,9 @@ function lockVerify(check) {
               errors.push("Invalid: lock file's " + name + '@' + lock.version + ' does not satisfy ' + name + '@' + spec.fetchSpec)
               return
             }
+            if (semver.minVersion(spec.fetchSpec).version !== lock.version) {
+              warnings.push('package-lock is newer than package: ' + lock.version + ' ' + spec.fetchSpec + ' ' + name)
+            }
           }
         } else if (spec.type === 'git') {
           // can't verify git w/o network

--- a/package-lock.json
+++ b/package-lock.json
@@ -489,6 +489,13 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "npm-package-arg": {
@@ -583,6 +590,13 @@
         "registry-auth-token": "^3.0.1",
         "registry-url": "^3.0.3",
         "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "parse-json": {
@@ -689,9 +703,9 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+      "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -699,6 +713,13 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
         "semver": "^5.0.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "set-blocking": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "author": "Rebecca Turner <me@re-becca.org> (http://re-becca.org/)",
   "license": "ISC",
   "dependencies": {
+    "@iarna/cli": "^1.2.0",
     "npm-package-arg": "^6.1.0",
-    "semver": "^5.4.1",
-    "@iarna/cli": "^1.2.0"
+    "semver": "^7.1.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# What / Why

Hi, I'm not sure this is change is welcome, but I wanted something like this for my own purposes anyway, so I thought I'll open the PR and see.

While the promise of `package-lock` is that no longer different developers have different versions of the same package and this promise is fulfilled, _it doesn't guarantee that version defined in `package.json` is actually the one that all the developers have_ if `package.json` field uses `^` or `~` ranges, (which is default behavior when someone does `npm install _some_package_`)

This is of course a known feature of `npm` and the whole point of having ranges. But it's still confusing. In fact, most of the time (by default) the two versions are aligned, _until someone nukes package-lock_ (for example due to merge conflict) and does `npm install` which regenerates it from scratch_.

This PR displays warnings like this in such a scenario:

```
Warning: package-lock is newer than package: 6.24.1 ^6.23.0 babel-plugin-transform-react-jsx
Warning: package-lock is newer than package: 4.2.8 ^4.2.3 node-bourbon
Warning: package-lock is newer than package: 6.10.3 ^6.9.0 eslint-plugin-react
Warning: package-lock is newer than package: 14.6.0 ^14.5.8 graphql
```

(I had to update semver to have `semver.minVersion`).

Looking forward to comments.